### PR TITLE
Ret 2946 shopify api v2020 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   ],
   "extra": {
     "branch-alias": {
-      "dev-master": "0.3.8"
+      "dev-master": "0.3.10"
     }
   }
 }

--- a/src/objects/BaseProvider.php
+++ b/src/objects/BaseProvider.php
@@ -15,7 +15,7 @@ class BaseProvider {
 	private $accessToken, $shopDomain;
 	private $headers;
 
-	private $shopify_api_version = '2020-07';
+	private $shopify_api_version = '2020-10';
 
 	public function __construct($args) {
 


### PR DESCRIPTION
I'm skipping a version to get around some weirdness in Core. The Lockfile thinks it's on version 3.9. 